### PR TITLE
Remove versions from deploy instructions

### DIFF
--- a/content/docs/faq.md
+++ b/content/docs/faq.md
@@ -80,8 +80,8 @@ The best solution to address this problem currently is to use [nidhogg](https://
 In certain situations deploying multiple separate Spegel clusters is beneficial. For example when a Kubernetes cluster spans multiple regions, it may be beneficial to limit nodes too only pull images from within the same region. Spegel can be deployed multiple times by simply using different names for each Helm deployment and setting a unique node selector. It is important to note that the node port service needs a unique port per deployment. Spegel will then only deploy on nodes with the matching labels and elect a unique leader for each deployment of Spegel. As the two Spegel clusters will never communicate they will not be able to discover layers outside of their own region, limiting requests to their specific region.
 
 ```bash
-helm upgrade --create-namespace --namespace spegel --install --version ${SPEGEL_VERSION} spegel-one oci://ghcr.io/spegel-org/helm-charts/spegel --set "nodeSelector.group=one" --set "service.registry.nodePort=30021"
-helm upgrade --create-namespace --namespace spegel --install --version ${SPEGEL_VERSION} spegel-two oci://ghcr.io/spegel-org/helm-charts/spegel --set "nodeSelector.group=two" --set "service.registry.nodePort=30022"
+helm upgrade --create-namespace --namespace spegel --install spegel-one oci://ghcr.io/spegel-org/helm-charts/spegel --set "nodeSelector.group=one" --set "service.registry.nodePort=30021"
+helm upgrade --create-namespace --namespace spegel --install spegel-two oci://ghcr.io/spegel-org/helm-charts/spegel --set "nodeSelector.group=two" --set "service.registry.nodePort=30022"
 ```
 
 ## Why are default memory requests and limits set in the Helm chart?

--- a/content/docs/getting-started.md
+++ b/content/docs/getting-started.md
@@ -5,6 +5,54 @@ weight: 1
 
 Before deploying Spegel read the compatibility section to make sure that the Kubernetes flavor of your choosing is supported or requires specific configuration to work.
 
+## Deploying
+
+Use the Helm chart to deploy Spegel into your Kubernetes cluster. Refer to the [Helm Chart](https://github.com/spegel-org/spegel/tree/main/charts/spegel) for detailed configuration documentation.
+
+### CLI
+
+To deploy Spegel with the Helm CLI run the command.
+
+```shell
+helm upgrade --create-namespace --namespace spegel --install spegel oci://ghcr.io/spegel-org/helm-charts/spegel
+```
+
+### Flux
+
+To deploy Spegel with Flux commit the configuration.
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: spegel
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: spegel
+  namespace: spegel
+spec:
+  type: "oci"
+  interval: 5m0s
+  url: oci://ghcr.io/spegel-org/helm-charts
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: spegel
+  namespace: spegel
+spec:
+  interval: 1m
+  chart:
+    spec:
+      chart: spegel
+      interval: 5m
+      sourceRef:
+        kind: HelmRepository
+        name: spegel
+```
+
 ## Compatibility
 
 Currently, Spegel only works with Containerd, in the future other container runtime interfaces may be supported. Spegel relies on [Containerd registry mirroring](https://github.com/containerd/containerd/blob/main/docs/hosts.md#cri) to route requests to the correct destination.
@@ -158,52 +206,3 @@ GKE does not set the registry config path in its Containerd configuration. On to
 ### DigitalOcean
 
 DigitalOcean does not set the registry config path in its Containerd configuration.
-
-## Deploying
-
-Use the Helm chart to deploy Spegel into your Kubernetes cluster. Refer to the [Helm Chart](https://github.com/spegel-org/spegel/tree/main/charts/spegel) for detailed configuration documentation.
-
-### CLI
-
-To deploy Spegel with the Helm CLI run the command.
-
-```shell
-helm upgrade --create-namespace --namespace spegel --install --version ${SPEGEL_VERSION} spegel oci://ghcr.io/spegel-org/helm-charts/spegel
-```
-
-### Flux
-
-To deploy Spegel with Flux commit the configuration.
-
-```yaml
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: spegel
----
-apiVersion: source.toolkit.fluxcd.io/v1beta2
-kind: HelmRepository
-metadata:
-  name: spegel
-  namespace: spegel
-spec:
-  type: "oci"
-  interval: 5m0s
-  url: oci://ghcr.io/spegel-org/helm-charts
----
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
-kind: HelmRelease
-metadata:
-  name: spegel
-  namespace: spegel
-spec:
-  interval: 1m
-  chart:
-    spec:
-      chart: spegel
-      version: ${SPEGEL_VERSION}
-      interval: 5m
-      sourceRef:
-        kind: HelmRepository
-        name: spegel
-```


### PR DESCRIPTION
Helm charts are now proper semver so Helm is able to find the latest version.