### PR TITLE
Simplify example IP extraction in getting-started.md

### DIFF
--- a/content/docs/getting-started.md
+++ b/content/docs/getting-started.md
@@ -150,7 +150,7 @@ Below you can find an example of a bootstrap container configuration that detect
 ```shell
 #!/bin/sh
 
-IP="$(awk '/32 host/ { print f } { f=$2 }' /proc/net/fib_trie | grep -v '127.0.0.1' | head -n1)"
+IP="$(awk '/32 host/ {if (f != "127.0.0.1") { print f; exit 0;  }} { f=$2 }' /proc/net/fib_trie)"
 [ -n "$IP" ] || exit 1
 
 apiclient set --json "{


### PR DESCRIPTION
Awk already has the ability to filter out expressions and quit after the first line printed.

This change demonstrates a variant that doesn't need the extra overhead, simply calculates the desired value in one process, no shell pipes, no forks.

In original and changed form, both results print out the first /32 address marked local that is not localhost.